### PR TITLE
Graph optimization

### DIFF
--- a/javersion-core/src/main/java/org/javersion/core/OptimizedGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/OptimizedGraph.java
@@ -1,0 +1,90 @@
+package org.javersion.core;
+
+import static com.google.common.collect.Lists.reverse;
+import static java.util.function.Function.identity;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+public class OptimizedGraph<K, V, M> {
+
+    private List<OptimizedVersionBuilder<K, V, M>> optimizedVersions;
+
+    public OptimizedGraph(VersionGraph<K, V, M, ?, ?> versionGraph, Iterable<Revision> revisions) {
+        Map<Revision, OptimizedVersionBuilder<K, V, M>> optimizedVersionsByRevision = new LinkedHashMap<>();
+        for (Revision revision : revisions) {
+            optimizedVersionsByRevision.put(revision, new OptimizedVersionBuilder<>(versionGraph.getVersionNode(revision)));
+        }
+        VersionNode<K, V, M> current = versionGraph.getTip();
+        while (current != null) {
+            if (!optimizedVersionsByRevision.containsKey(current.getRevision())) {
+                Set<Revision> childRevisions = new HashSet<>();
+                for (OptimizedVersionBuilder<K, V, M> versionBuilder : optimizedVersionsByRevision.values()) {
+                    if (versionBuilder.requiresParent(current.revision)) {
+                        childRevisions.add(versionBuilder.getRevision());
+                    }
+                }
+                if (childRevisions.size() > 1) {
+                    for (Revision childRevision : childRevisions) {
+                        OptimizedVersionBuilder<K, V, M> versionBuilder = optimizedVersionsByRevision.get(childRevision);
+                        versionBuilder.addParent(current);
+                    }
+                    optimizedVersionsByRevision.put(current.revision, new OptimizedVersionBuilder<>(current));
+                }
+            }
+            current = (current.previousRevision != null ? versionGraph.getVersionNode(current.previousRevision) : null);
+        }
+        optimizedVersions = reverse(new ArrayList<>(optimizedVersionsByRevision.values()));
+    }
+
+    public Iterable<Version<K, V, M>> getOptimizedVersions() {
+        return optimizedVersions.stream()
+                .map(optimizedVersion -> optimizedVersion.build(identity()))
+                .collect(Collectors.toList());
+    }
+
+    private static class OptimizedVersionBuilder<K, V, M> {
+
+        private VersionNode<K, V, M> versionNode;
+
+        private Set<VersionNode<K, V, M>> newParents = new HashSet<>();
+
+        OptimizedVersionBuilder(VersionNode<K, V, M> versionNode) {
+            this.versionNode = versionNode;
+        }
+
+        boolean requiresParent(Revision revision) {
+            return versionNode.mergedRevisions.contains(revision)
+                    && newParents.stream().noneMatch(parent -> parent.mergedRevisions.contains(revision));
+        }
+
+        public Revision getRevision() {
+            return versionNode.revision;
+        }
+
+        public void addParent(VersionNode<K, V, M> parentCandidate) {
+            for (VersionNode<K, V, M> parent : newParents) {
+                // parentCandidate is inherited
+                if (parent.mergedRevisions.contains(parentCandidate)) {
+                    return;
+                }
+            }
+            newParents.add(parentCandidate);
+        }
+
+        public Version<K, V, M> build(Function<Revision, Revision> idMapper) {
+            return new Version.Builder<K, V, M>(idMapper.apply(versionNode.getRevision()))
+                    .branch(versionNode.getBranch())
+                    .meta(versionNode.getMeta())
+                    .parents(getParentRevisions(idMapper))
+                    .changeset(versionNode.getProperties())
+                    .build();
+        }
+
+        private Set<Revision> getParentRevisions(Function<Revision, Revision> idMapper) {
+            return newParents.stream().map(VersionNode::getRevision).map(idMapper).collect(Collectors.toSet());
+        }
+    }
+}

--- a/javersion-core/src/main/java/org/javersion/core/Revision.java
+++ b/javersion-core/src/main/java/org/javersion/core/Revision.java
@@ -27,7 +27,7 @@ public final class Revision implements Comparable<Revision> {
 
     public static final Revision MAX_VALUE = new Revision(-1, -1);
 
-    private static final long NODE = UUIDGen.getClockSeqAndNode();
+    public static final long NODE = UUIDGen.getClockSeqAndNode();
 
     public final long timeSeq;
 

--- a/javersion-core/src/main/java/org/javersion/core/SimpleVersion.java
+++ b/javersion-core/src/main/java/org/javersion/core/SimpleVersion.java
@@ -21,6 +21,10 @@ public class SimpleVersion extends Version<String, String, String> {
         super(builder);
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static class Builder extends BuilderBase<String, String, String, Builder> {
 
         public Builder() {

--- a/javersion-core/src/main/java/org/javersion/core/SimpleVersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/SimpleVersionGraph.java
@@ -15,21 +15,21 @@
  */
 package org.javersion.core;
 
+import static java.util.Arrays.asList;
+
 public final class SimpleVersionGraph extends VersionGraph<String, String, String, SimpleVersionGraph, SimpleVersionGraph.Builder> {
 
     public static SimpleVersionGraph init() {
         return new SimpleVersionGraph();
     }
 
-    public static SimpleVersionGraph init(SimpleVersion version) {
-        Builder builder = new Builder();
-        builder.add(version);
-        return builder.build();
+    public static SimpleVersionGraph init(Version<String, String, String>... versions) {
+        return init(asList(versions));
     }
 
-    public static SimpleVersionGraph init(Iterable<SimpleVersion> versions) {
+    public static SimpleVersionGraph init(Iterable<? extends Version<String, String, String>> versions) {
         Builder builder = new Builder();
-        for (SimpleVersion version : versions) {
+        for (Version<String, String, String> version : versions) {
             builder.add(version);
         }
         return builder.build();
@@ -46,6 +46,11 @@ public final class SimpleVersionGraph extends VersionGraph<String, String, Strin
     @Override
     protected Builder newBuilder() {
         return new Builder(this);
+    }
+
+    @Override
+    protected Builder newEmptyBuilder() {
+        return new Builder();
     }
 
     static class Builder extends VersionGraphBuilder<String, String, String, SimpleVersionGraph, Builder> {

--- a/javersion-core/src/main/java/org/javersion/core/Version.java
+++ b/javersion-core/src/main/java/org/javersion/core/Version.java
@@ -68,6 +68,10 @@ public class Version<K, V, M> {
         this.parentRevisions = builder.parentRevisions != null ? copyOf(builder.parentRevisions) : EMPTY_PARENTS;
         this.changeset = builder.changeset != null ? unmodifiableMap(newLinkedHashMap(builder.changeset)) : ImmutableMap.of();
         this.meta = builder.meta;
+
+        if (parentRevisions.contains(revision)) {
+            throw new IllegalArgumentException("parentRevisions should not contain own revision");
+        }
     }
 
     public Map<K, VersionProperty<V>> getVersionProperties() {

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
@@ -23,7 +23,6 @@ import static org.javersion.core.BranchAndRevision.max;
 import static org.javersion.core.BranchAndRevision.min;
 import static org.javersion.util.MapUtils.mapValueFunction;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,6 +32,7 @@ import org.javersion.util.PersistentSortedMap;
 import org.javersion.util.PersistentTreeMap;
 
 import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 public abstract class VersionGraph<K, V, M,
@@ -151,14 +151,11 @@ public abstract class VersionGraph<K, V, M,
      * @return versions in newest first (or reverse topological) order.
      */
     public final Iterable<Version<K, V, M>> getVersions() {
-        // TODO: custom Iterable using current.previousVersion links for Iterator
-        List<Version<K, V, M>> versions = new ArrayList<>(versionNodes.size());
-        VersionNode<K, V, M> current = tip;
-        while (current != null) {
-            versions.add(current.getVersion());
-            current = (current.previousRevision != null ? versionNodes.get(current.previousRevision) : null);
-        }
-        return versions;
+        return Iterables.transform(getVersionNodes(), VersionNode::getVersion);
+    }
+
+    public final Iterable<VersionNode<K, V, M>> getVersionNodes() {
+        return new VersionNodeIterable<>(getTip(), versionNodes);
     }
 
     public This optimize(Revision... revisions) {

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
@@ -156,6 +156,9 @@ public abstract class VersionGraph<K, V, M,
         return Iterables.transform(getVersionNodes(), VersionNode::getVersion);
     }
 
+    /**
+     * @return versions in newest first (or reverse topological) order.
+     */
     public final Iterable<VersionNode<K, V, M>> getVersionNodes() {
         return new VersionNodeIterable<>(getTip(), versionNodes);
     }

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
@@ -25,6 +25,7 @@ import static org.javersion.util.MapUtils.mapValueFunction;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.javersion.util.PersistentMap;
@@ -32,6 +33,7 @@ import org.javersion.util.PersistentSortedMap;
 import org.javersion.util.PersistentTreeMap;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -159,10 +161,14 @@ public abstract class VersionGraph<K, V, M,
     }
 
     public This optimize(Revision... revisions) {
-        return optimize(asList(revisions));
+        return optimize(ImmutableSet.copyOf(revisions));
     }
 
-    public This optimize(Iterable<Revision> revisions) {
+    public This optimize(Set<Revision> revisions) {
+        return optimize(versionNode -> revisions.contains(versionNode.revision));
+    }
+
+    public This optimize(Predicate<VersionNode<K, V, M>> revisions) {
         B builder = newEmptyBuilder();
         for (Version<K, V, M> version : new OptimizedGraph<>(this, revisions).getOptimizedVersions()) {
             builder.add(version);

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
@@ -170,7 +170,7 @@ public abstract class VersionGraph<K, V, M,
 
     public This optimize(Predicate<VersionNode<K, V, M>> revisions) {
         B builder = newEmptyBuilder();
-        for (Version<K, V, M> version : new OptimizedGraph<>(this, revisions).getOptimizedVersions()) {
+        for (Version<K, V, M> version : new OptimizedGraphBuilder<>(this, revisions).getOptimizedVersions()) {
             builder.add(version);
         }
         return builder.build();

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraphBuilder.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraphBuilder.java
@@ -59,6 +59,9 @@ public abstract class VersionGraphBuilder<K, V, M,
 
     public final void add(Version<K, V, M> version) {
         Check.notNull(version, "version");
+        if (versionNodes.containsKey(version.revision)) {
+            throw new IllegalArgumentException("Duplicate revision: " + version);
+        }
         MutableSortedMap<BranchAndRevision, VersionNode<K, V, M>> mutableHeads = heads.toMutableMap();
         MergeBuilder<K, V, M> mergeBuilder = new MergeBuilder<>();
 

--- a/javersion-core/src/main/java/org/javersion/core/VersionNode.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionNode.java
@@ -65,6 +65,10 @@ public final class VersionNode<K, V, M> extends Merge<K, V, M> {
         return branch;
     }
 
+    public M getMeta() {
+        return meta;
+    }
+
     @Override
     public Set<Revision> getMergeHeads() {
         return ImmutableSet.of(revision);
@@ -92,5 +96,9 @@ public final class VersionNode<K, V, M> extends Merge<K, V, M> {
                 .parents(parentRevisions)
                 .changeset(getChangeset())
                 .build();
+    }
+
+    public Set<Revision> getParentRevisions() {
+        return parentRevisions;
     }
 }

--- a/javersion-core/src/main/java/org/javersion/core/VersionNode.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionNode.java
@@ -101,4 +101,8 @@ public final class VersionNode<K, V, M> extends Merge<K, V, M> {
     public Set<Revision> getParentRevisions() {
         return parentRevisions;
     }
+
+    public String toString() {
+        return revision.toString();
+    }
 }

--- a/javersion-core/src/main/java/org/javersion/core/VersionNodeIterable.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionNodeIterable.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Samppa Saarela
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javersion.core;
+
+import java.util.Iterator;
+
+import org.javersion.util.PersistentMap;
+
+public class VersionNodeIterable<K, V, M> implements Iterable<VersionNode<K, V, M>> {
+
+    private final VersionNode<K, V, M> tip;
+
+    private final PersistentMap<Revision, VersionNode<K, V, M>> versionNodes;
+
+    public VersionNodeIterable(VersionNode<K, V, M> tip, PersistentMap<Revision, VersionNode<K, V, M>> versionNodes) {
+        this.tip = tip;
+        this.versionNodes = versionNodes;
+    }
+
+    @Override
+    public Iterator<VersionNode<K, V, M>> iterator() {
+        return new Iterator<VersionNode<K, V, M>>() {
+
+            private VersionNode<K, V, M> current = tip;
+
+            @Override
+            public boolean hasNext() {
+                return current != null;
+            }
+
+            @Override
+            public VersionNode<K, V, M> next() {
+                VersionNode<K, V, M> next = current;
+                current = (current.previousRevision != null ? versionNodes.get(current.previousRevision) : null);
+                return next;
+            }
+        };
+    }
+
+}

--- a/javersion-core/src/test/java/org/javersion/core/SimpleVersionGraphTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/SimpleVersionGraphTest.java
@@ -560,6 +560,17 @@ public class SimpleVersionGraphTest {
         assertThat(versionGraph.getTip().revision, equalTo(v1.revision));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void duplicate_revision_throws_exception() {
+        Revision rev = new Revision();
+        SimpleVersion v1 = new SimpleVersion.Builder(rev)
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder(rev)
+                .build();
+
+        SimpleVersionGraph.init(asList(v1, v2));
+    }
+
     private int findIndex(List<VersionExpectation> expectations, int versionNumber) {
         for (int i=0; i < expectations.size(); i++) {
             Revision revision = expectations.get(i).getRevision();

--- a/javersion-core/src/test/java/org/javersion/core/SimpleVersionGraphTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/SimpleVersionGraphTest.java
@@ -18,6 +18,7 @@ package org.javersion.core;
 import static com.google.common.base.Predicates.notNull;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -390,7 +391,7 @@ public class SimpleVersionGraphTest {
     }
 
     static List<List<VersionExpectation>> getBulkExpectations() {
-        List<List<VersionExpectation>> bulks = Lists.newArrayList();
+        List<List<VersionExpectation>> bulks = newArrayList();
         for (int i=1; i<= EXPECTATIONS.size(); i++) {
             bulks.add(EXPECTATIONS.subList(0, i));
         }
@@ -428,7 +429,7 @@ public class SimpleVersionGraphTest {
     public void Tip_of_an_Empty_Graph() {
         SimpleVersionGraph versionGraph = SimpleVersionGraph.init();
         assertNull(versionGraph.getTip());
-        assertTrue(versionGraph.getVersions().isEmpty());
+        assertTrue(newArrayList(versionGraph.getVersions()).isEmpty());
     }
 
     @Test(expected = VersionNotFoundException.class)

--- a/javersion-core/src/test/java/org/javersion/core/SimpleVersionTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/SimpleVersionTest.java
@@ -1,0 +1,14 @@
+package org.javersion.core;
+
+import org.junit.Test;
+
+public class SimpleVersionTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cannot_have_self_as_parent() {
+        Revision rev = new Revision();
+        new SimpleVersion.Builder(rev)
+                .parents(rev)
+                .build();
+    }
+}

--- a/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
@@ -1,0 +1,183 @@
+package org.javersion.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.javersion.core.SimpleVersionGraphTest.mapOf;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+public class VersionGraphOptimizationTest {
+
+    /**
+     *  1
+     *  2
+     *  3
+     */
+    @Test
+    public void squash_linear_history() {
+        SimpleVersion v1 = new SimpleVersion.Builder()
+                .changeset(mapOf("key", "value1"))
+                .meta("v1 meta")
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key", "value2"))
+                .meta("v2 meta")
+                .build();
+        SimpleVersion v3 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key2", "value1"))
+                .meta("v3 meta")
+                .build();
+
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3);
+
+        SimpleVersionGraph graph = versionGraph.optimize(v3.revision);
+
+        assertNotFound(graph, v2.revision);
+        assertNotFound(graph, v1.revision);
+
+        VersionNode<String, String, String> node = graph.getVersionNode(v3.revision);
+        assertThat(node.getChangeset()).isEqualTo(mapOf("key", "value2", "key2", "value1"));
+        assertThat(node.getParentRevisions()).isEmpty();
+        assertThat(node.getMeta()).isEqualTo("v3 meta");
+    }
+
+    /**
+     *  1
+     *  2
+     * 3 4
+     */
+    @Test
+    public void y_inheritance() {
+        SimpleVersion v1 = new SimpleVersion.Builder()
+                .changeset(mapOf("key", "value1"))
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key", "value2"))
+                .build();
+        SimpleVersion v3 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key2", "value1"))
+                .build();
+        SimpleVersion v4 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key3", "value1"))
+                .build();
+
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4);
+
+        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+
+        // Keep v2, v3 and v4
+        assertNotFound(graph, v1.revision);
+
+        VersionNode<String, String, String> v2node = graph.getVersionNode(v2.revision);
+        assertThat(v2node.getChangeset()).isEqualTo(mapOf("key", "value2"));
+        assertThat(v2node.getParentRevisions()).isEmpty();
+
+        VersionNode<String, String, String> v3node = graph.getVersionNode(v3.revision);
+        assertThat(v3node.getChangeset()).isEqualTo(mapOf("key2", "value1"));
+        assertThat(v3node.getParentRevisions()).isEqualTo(ImmutableSet.of(v2.revision));
+
+        VersionNode<String, String, String> v4node = graph.getVersionNode(v4.revision);
+        assertThat(v4node.getChangeset()).isEqualTo(mapOf("key3", "value1"));
+        assertThat(v4node.getParentRevisions()).isEqualTo(ImmutableSet.of(v2.revision));
+    }
+
+    /**
+     *  1
+     * 2 3
+     *  4
+     */
+    @Test
+    public void diamond_inheritance() {
+        SimpleVersion v1 = new SimpleVersion.Builder()
+                .changeset(mapOf("key1", "value1"))
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key2", "value1"))
+                .build();
+        SimpleVersion v3 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key2", "value2"))
+                .build();
+        SimpleVersion v4 = new SimpleVersion.Builder()
+                .parents(v2.revision, v3.revision)
+                .changeset(mapOf("key3", "value1"))
+                .build();
+
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4);
+
+        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+
+        // Keep only v4
+        assertNotFound(graph, v1.revision);
+        assertNotFound(graph, v2.revision);
+        assertNotFound(graph, v3.revision);
+
+        VersionNode<String, String, String> v4node = graph.getVersionNode(v4.revision);
+        assertThat(v4node.getChangeset()).isEqualTo(mapOf("key1", "value1", "key2", "value2", "key3", "value1"));
+        assertThat(v4node.getParentRevisions()).isEmpty();
+    }
+
+    /**
+     *   1
+     *   2
+     *  3 4
+     *   5
+     */
+    @Test
+    public void remove_tombstones() {
+        SimpleVersion v1 = new SimpleVersion.Builder()
+                .changeset(mapOf("key1", "value1"))
+                .changeset(mapOf("key2", "value1"))
+                .changeset(mapOf("key3", "value1"))
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key1", null))
+                .build();
+        SimpleVersion v3 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key2", null))
+                .build();
+        SimpleVersion v4 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key3", null))
+                .build();
+        SimpleVersion v5 = new SimpleVersion.Builder()
+                .parents(v3.revision, v4.revision)
+                .changeset(mapOf("key4", "value1"))
+                .build();
+
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4, v5);
+
+        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+
+        // Keep only v4
+        assertNotFound(graph, v1.revision);
+        assertNotFound(graph, v2.revision);
+        assertNotFound(graph, v3.revision);
+        assertNotFound(graph, v4.revision);
+
+        VersionNode<String, String, String> v4node = graph.getVersionNode(v5.revision);
+        assertThat(v4node.getChangeset()).isEqualTo(mapOf("key4", "value1"));
+        assertThat(v4node.getParentRevisions()).isEmpty();
+    }
+
+    private void assertNotFound(SimpleVersionGraph graph, Revision revision) {
+        try {
+            graph.getVersionNode(revision);
+            fail("Revision should not have been found");
+        } catch (VersionNotFoundException e) {
+            // as expected
+        }
+    }
+
+
+}

--- a/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.javersion.core.SimpleVersionGraphTest.mapOf;
 
+import java.util.Set;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class VersionGraphOptimizationTest {
 
@@ -70,7 +74,7 @@ public class VersionGraphOptimizationTest {
 
         SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4);
 
-        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+        SimpleVersionGraph graph = versionGraph.optimize(v3.revision, v4.revision);
 
         // Keep v2, v3 and v4
         assertNotFound(graph, v1.revision);
@@ -113,7 +117,7 @@ public class VersionGraphOptimizationTest {
 
         SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4);
 
-        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+        SimpleVersionGraph graph = versionGraph.optimize(v4.revision);
 
         // Keep only v4
         assertNotFound(graph, v1.revision);
@@ -134,9 +138,7 @@ public class VersionGraphOptimizationTest {
     @Test
     public void remove_tombstones() {
         SimpleVersion v1 = new SimpleVersion.Builder()
-                .changeset(mapOf("key1", "value1"))
-                .changeset(mapOf("key2", "value1"))
-                .changeset(mapOf("key3", "value1"))
+                .changeset(mapOf("key1", "value1", "key2", "value1", "key3", "value1"))
                 .build();
         SimpleVersion v2 = new SimpleVersion.Builder()
                 .parents(v1.revision)
@@ -157,7 +159,7 @@ public class VersionGraphOptimizationTest {
 
         SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3, v4, v5);
 
-        SimpleVersionGraph graph = versionGraph.optimize(versionGraph.getHeadRevisions());
+        SimpleVersionGraph graph = versionGraph.optimize(v5.revision);
 
         // Keep only v4
         assertNotFound(graph, v1.revision);
@@ -168,6 +170,70 @@ public class VersionGraphOptimizationTest {
         VersionNode<String, String, String> v4node = graph.getVersionNode(v5.revision);
         assertThat(v4node.getChangeset()).isEqualTo(mapOf("key4", "value1"));
         assertThat(v4node.getParentRevisions()).isEmpty();
+    }
+
+    @Test
+    public void keep_all() {
+        SimpleVersion v1 = new SimpleVersion.Builder()
+                .changeset(mapOf("key", "value1"))
+                .build();
+        SimpleVersion v2 = new SimpleVersion.Builder()
+                .parents(v1.revision)
+                .changeset(mapOf("key1", "value1"))
+                .build();
+        SimpleVersion v3 = new SimpleVersion.Builder()
+                .parents(v2.revision)
+                .changeset(mapOf("key2", "value1"))
+                .build();
+
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init(v1, v2, v3);
+
+        SimpleVersionGraph graph = versionGraph.optimize(v1.revision, v2.revision, v3.revision);
+
+        VersionNode<String, String, String> node = graph.getVersionNode(v1.revision);
+        assertThat(node.getChangeset()).isEqualTo(mapOf("key", "value1"));
+        assertThat(node.getParentRevisions()).isEmpty();
+
+        node = graph.getVersionNode(v2.revision);
+        assertThat(node.getChangeset()).isEqualTo(mapOf("key1", "value1"));
+        assertThat(node.getParentRevisions()).isEqualTo(ImmutableSet.of(v1.revision));
+
+        node = graph.getVersionNode(v3.revision);
+        assertThat(node.getChangeset()).isEqualTo(mapOf("key2", "value1"));
+        assertThat(node.getParentRevisions()).isEqualTo(ImmutableSet.of(v2.revision));
+    }
+
+    @Test
+    public void performance() {
+        int COUNT = 100000;
+        Set<Revision> revisions = Sets.newHashSetWithExpectedSize(COUNT);
+        SimpleVersionGraph versionGraph = SimpleVersionGraph.init();
+        Revision prev = null;
+        for (int i=0; i<COUNT;i++) {
+            SimpleVersion.Builder versionBuilder = new SimpleVersion.Builder()
+                    .changeset(mapOf("key", Integer.toString(i)));
+            if (prev != null) {
+                versionBuilder.parents(prev);
+            }
+            versionGraph = versionGraph.commit(versionBuilder.build());
+            prev = versionGraph.getTip().getRevision();
+            revisions.add(prev);
+        }
+        System.out.println("begin " + COUNT);
+        long time, ts = System.currentTimeMillis();
+
+        SimpleVersionGraph optimizedGraph = versionGraph.optimize(versionGraph.getTip().revision);
+        time = System.currentTimeMillis() - ts;
+        System.out.println("keep tip only: " + time);
+        assertThat(optimizedGraph.getTip().getProperties()).isEqualTo(mapOf("key", Integer.toString(COUNT - 1)));
+        assertThat(Lists.newArrayList(optimizedGraph.getVersionNodes())).hasSize(1);
+
+        ts = System.currentTimeMillis();
+        optimizedGraph = versionGraph.optimize(revisions);
+        time = System.currentTimeMillis() - ts;
+        System.out.println("keep all revisions: " + time);
+        assertThat(optimizedGraph.getTip().getProperties()).isEqualTo(mapOf("key", Integer.toString(COUNT - 1)));
+        assertThat(Lists.newArrayList(optimizedGraph.getVersionNodes())).hasSize(COUNT);
     }
 
     private void assertNotFound(SimpleVersionGraph graph, Revision revision) {

--- a/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
@@ -205,7 +205,7 @@ public class VersionGraphOptimizationTest {
 
     @Test
     public void performance() {
-        int COUNT = 100000;
+        int COUNT = 10000;
         Set<Revision> revisions = Sets.newHashSetWithExpectedSize(COUNT);
         SimpleVersionGraph versionGraph = SimpleVersionGraph.init();
         Revision prev = null;

--- a/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
+++ b/javersion-core/src/test/java/org/javersion/core/VersionGraphOptimizationTest.java
@@ -234,6 +234,8 @@ public class VersionGraphOptimizationTest {
         System.out.println("keep all revisions: " + time);
         assertThat(optimizedGraph.getTip().getProperties()).isEqualTo(mapOf("key", Integer.toString(COUNT - 1)));
         assertThat(Lists.newArrayList(optimizedGraph.getVersionNodes())).hasSize(COUNT);
+
+        System.out.flush();
     }
 
     private void assertNotFound(SimpleVersionGraph graph, Revision revision) {

--- a/javersion-object/src/main/java/org/javersion/object/ObjectVersionGraph.java
+++ b/javersion-object/src/main/java/org/javersion/object/ObjectVersionGraph.java
@@ -65,6 +65,11 @@ public final class ObjectVersionGraph<M> extends VersionGraph<PropertyPath, Obje
         return new Builder<M>(this);
     }
 
+    @Override
+    protected Builder<M> newEmptyBuilder() {
+        return new Builder<>();
+    }
+
     public static class Builder<M> extends VersionGraphBuilder<PropertyPath, Object, M, ObjectVersionGraph<M>, Builder<M>> {
 
         public Builder() {

--- a/javersion-spring-jdbc/src/test/java/org/javersion/store/jdbc/ObjectVersionStoreJdbcTest.java
+++ b/javersion-spring-jdbc/src/test/java/org/javersion/store/jdbc/ObjectVersionStoreJdbcTest.java
@@ -1,5 +1,6 @@
 package org.javersion.store.jdbc;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.javersion.path.PropertyPath.ROOT;
@@ -128,7 +129,7 @@ public class ObjectVersionStoreJdbcTest {
         versionStore.append(docId, versionGraph.getTip());
         versionStore.publish();
         versionGraph = versionStore.load(docId);
-        List<Version<PropertyPath, Object, Void>> versions = versionGraph.getVersions();
+        List<Version<PropertyPath, Object, Void>> versions = newArrayList(versionGraph.getVersions());
         assertThat(versions).hasSize(1);
         assertThat(versions.get(0)).isEqualTo(emptyVersion);
     }

--- a/javersion-spring-jdbc/src/test/java/org/javersion/store/jdbc/ObjectVersionStoreJdbcTest.java
+++ b/javersion-spring-jdbc/src/test/java/org/javersion/store/jdbc/ObjectVersionStoreJdbcTest.java
@@ -1,14 +1,15 @@
 package org.javersion.store.jdbc;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.javersion.path.PropertyPath.ROOT;
+import static org.javersion.path.PropertyPath.parse;
 import static org.javersion.store.sql.QTestVersion.testVersion;
 import static org.javersion.store.sql.QTestVersionProperty.testVersionProperty;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -19,6 +20,7 @@ import org.javersion.core.Persistent;
 import org.javersion.core.Revision;
 import org.javersion.core.Version;
 import org.javersion.core.VersionGraph;
+import org.javersion.core.VersionNode;
 import org.javersion.object.ObjectVersion;
 import org.javersion.object.ObjectVersionBuilder;
 import org.javersion.object.ObjectVersionGraph;
@@ -33,8 +35,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.mysema.query.sql.SQLQueryFactory;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -147,7 +150,7 @@ public class ObjectVersionStoreJdbcTest {
         new Thread(() -> {
             transactionTemplate.execute(status -> {
                 ObjectVersion<Void> version1 = ObjectVersion.<Void>builder(r1)
-                        .changeset(ImmutableMap.of(ROOT.property("concurrency"), " slow"))
+                        .changeset(mapOf(ROOT.property("concurrency"), " slow"))
                         .build();
                 versionStore.append(docId, ObjectVersionGraph.init(version1).getTip());
 
@@ -168,7 +171,7 @@ public class ObjectVersionStoreJdbcTest {
         firstInsertDone.await();
 
         ObjectVersion<Void> version2 = ObjectVersion.<Void>builder(r2)
-                .changeset(ImmutableMap.of(ROOT.property("concurrency"), "fast"))
+                .changeset(mapOf("concurrency", "fast"))
                 .build();
         versionStore.append(docId, ObjectVersionGraph.init(version2).getTip());
         versionStore.publish();
@@ -216,11 +219,11 @@ public class ObjectVersionStoreJdbcTest {
         String docId = randomUUID().toString();
 
         ObjectVersion<Void> v1 = ObjectVersion.<Void>builder()
-                .changeset(ImmutableMap.of(ROOT.property("property"), "value1"))
+                .changeset(mapOf("property", "value1"))
                 .build();
 
         ObjectVersion<Void> v2 = ObjectVersion.<Void>builder()
-                .changeset(ImmutableMap.of(ROOT.property("property"), "value2"))
+                .changeset(mapOf("property", "value2"))
                 .build();
 
         ObjectVersionGraph<Void> versionGraph = ObjectVersionGraph.init(v1, v2);
@@ -237,19 +240,146 @@ public class ObjectVersionStoreJdbcTest {
         assertThat(updates.get(0)).isEqualTo(v2);
     }
 
+    /**
+     *   v1
+     *   |
+     *   v2
+     *   |
+     *   v3*
+     *  /  \
+     * v4  v5*
+     * |
+     * v6*
+     */
+    @Test
+    public void optimize() {
+        String docId = randomUUID().toString();
+
+        ObjectVersion<Void> v1 = ObjectVersion.<Void>builder()
+                .changeset(mapOf(
+                        // This should ve moved to v3
+                        "property1", "value1",
+                        "property2", "value1"))
+                .build();
+
+        ObjectVersion<Void> v2 = ObjectVersion.<Void>builder()
+                // Toombstones should be removed
+                .changeset(mapOf("property2", null))
+                .parents(v1.revision)
+                .build();
+
+        ObjectVersion<Void> v3 = ObjectVersion.<Void>builder()
+                .parents(v2.revision)
+                .build();
+
+        // This intermediate version should be removed
+        ObjectVersion<Void> v4 = ObjectVersion.<Void>builder()
+                .changeset(mapOf(
+                        // These should be left as is
+                        "property1", "value2",
+                        "property2", "value1"))
+                .parents(v3.revision)
+                .build();
+
+        ObjectVersion<Void> v5 = ObjectVersion.<Void>builder()
+                // This should be in conflict with v4
+                .changeset(mapOf("property2", "value2"))
+                .parents(v3.revision)
+                .build();
+
+        ObjectVersion<Void> v6 = ObjectVersion.<Void>builder()
+                // This should be replaced with v3
+                .parents(v4.revision)
+                .build();
+
+        ObjectVersionGraph<Void> versionGraph = ObjectVersionGraph.init(v1, v2, v3, v4, v5, v6);
+        versionStore.append(docId, ImmutableList.copyOf(versionGraph.getVersionNodes()).reverse());
+        versionStore.publish();
+
+        assertThat(queryFactory.from(testVersion).where(testVersion.docId.eq(docId)).count()).isEqualTo(6);
+
+        versionStore.optimize(docId,
+                versionNode -> versionNode.revision.equals(v5.revision) || versionNode.revision.equals(v6.revision));
+
+        assertThat(queryFactory.from(testVersion).where(testVersion.docId.eq(docId)).count()).isEqualTo(3);
+
+        versionGraph = versionStore.load(docId);
+
+        VersionNode<PropertyPath, Object, Void> versionNode = versionGraph.getVersionNode(v3.revision);
+        assertThat(versionNode.getParentRevisions()).isEmpty();
+        // Toombstone is removed
+        assertThat(versionNode.getChangeset()).isEqualTo(mapOf("property1", "value1"));
+        assertThat(versionNode.getProperties()).doesNotContainKey(parse("property2"));
+
+        versionNode = versionGraph.getVersionNode(v5.revision);
+        assertThat(versionNode.getParentRevisions()).isEqualTo(ImmutableSet.of(v3.revision));
+        assertThat(versionNode.getChangeset()).isEqualTo(mapOf("property2", "value2"));
+
+        versionNode = versionGraph.getVersionNode(v6.revision);
+        assertThat(versionNode.getParentRevisions()).isEqualTo(ImmutableSet.of(v3.revision));
+        assertThat(versionNode.getChangeset()).isEqualTo(mapOf(
+                "property1", "value2",
+                "property2", "value1"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void optimize_should_not_delete_all_versions() {
+        String docId = randomUUID().toString();
+
+        ObjectVersion<Void> v1 = ObjectVersion.<Void>builder()
+                .changeset(mapOf("property1", "value1"))
+                .build();
+
+        ObjectVersionGraph<Void> versionGraph = ObjectVersionGraph.init(v1);
+        versionStore.append(docId, ImmutableList.copyOf(versionGraph.getVersionNodes()).reverse());
+        versionStore.publish();
+
+        versionStore.optimize(docId, v -> false);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void unpublished_version_may_prevent_optimization() {
+        String docId = randomUUID().toString();
+
+        ObjectVersion<Void> v1 = ObjectVersion.<Void>builder()
+                .changeset(mapOf("property1", "value1"))
+                .build();
+
+        ObjectVersion<Void> v2 = ObjectVersion.<Void>builder()
+                .changeset(mapOf("property1", "value2"))
+                .parents(v1.revision)
+                .build();
+
+        ObjectVersion<Void> v3 = ObjectVersion.<Void>builder()
+                .changeset(mapOf("property1", "value3"))
+                // v1 is to be squashed...
+                .parents(v1.revision)
+                .build();
+
+        ObjectVersionGraph<Void> versionGraph = ObjectVersionGraph.init(v1, v2);
+        versionStore.append(docId, ImmutableList.copyOf(versionGraph.getVersionNodes()).reverse());
+        versionStore.publish();
+
+        versionGraph = versionGraph.commit(v3);
+        versionStore.append(docId, versionGraph.getVersionNode(v3.revision));
+
+        // v3 is not published yet!
+        versionStore.optimize(docId, v -> v.revision.equals(v2.revision));
+    }
+
     @Test
     public void supported_value_types() {
         String docId = randomUUID().toString();
 
-        Map<PropertyPath, Object> changeset = new HashMap<>();
-        changeset.put(ROOT.property("Object"), Persistent.object("Object"));
-        changeset.put(ROOT.property("Array"), Persistent.array());
-        changeset.put(ROOT.property("String"), "String");
-        changeset.put(ROOT.property("Boolean"), true);
-        changeset.put(ROOT.property("Long"), 123l);
-        changeset.put(ROOT.property("Double"), 123.456);
-        changeset.put(ROOT.property("BigDecimal"), BigDecimal.TEN);
-        changeset.put(ROOT.property("Void"), null);
+        Map<PropertyPath, Object> changeset = mapOf(
+            "Object", Persistent.object("Object"),
+            "Array", Persistent.array(),
+            "String", "String",
+            "Boolean", true,
+            "Long", 123l,
+            "Double", 123.456,
+            "BigDecimal", BigDecimal.TEN,
+            "Void", null);
 
         ObjectVersion<Void> version = ObjectVersion.<Void>builder().changeset(changeset).build();
         versionStore.append(docId, ObjectVersionGraph.init(version).getTip());
@@ -262,9 +392,9 @@ public class ObjectVersionStoreJdbcTest {
         String docId = randomUUID().toString();
 
         ObjectVersion<Void> v1 = ObjectVersion.<Void>builder()
-                .changeset(ImmutableMap.<PropertyPath, Object>of(
-                        ROOT.property("name"), "name",
-                        ROOT.property("id"), 5l))
+                .changeset(mapOf(
+                        "name", "name",
+                        "id", 5l))
                 .build();
 
         mappedVersionStore.append(docId, ObjectVersionGraph.init(v1).getTip());
@@ -293,6 +423,15 @@ public class ObjectVersionStoreJdbcTest {
                 .count();
         assertThat(count).isEqualTo(1);
         assertThat(mappedVersionStore.load(docId).getTip().getVersion()).isEqualTo(v2);
+    }
+
+
+    public static Map<PropertyPath, Object> mapOf(Object... entries) {
+        Map<PropertyPath, Object> map = Maps.newHashMap();
+        for (int i=0; i+1 < entries.length; i+=2) {
+            map.put(parse(entries[i].toString()), entries[i+1]);
+        }
+        return unmodifiableMap(map);
     }
 
 }

--- a/javersion-util/src/main/java/org/javersion/util/AbstractHashTrie.java
+++ b/javersion-util/src/main/java/org/javersion/util/AbstractHashTrie.java
@@ -84,6 +84,17 @@ public abstract class AbstractHashTrie<K, E extends EntryNode<K, E>, This extend
         return commitAndReturn(updateContext, newRoot, size() + updateContext.getChangeAndReset());
     }
 
+    @SuppressWarnings("rawtypes")
+    protected final This doRemoveAll(UpdateContext<? super E> updateContext, Iterator keys) {
+        Node<K, E> newRoot = root();
+        int size = size();
+        while (keys.hasNext()) {
+            newRoot = newRoot.dissoc(updateContext, keys.next());
+            size += updateContext.getChangeAndReset();
+        }
+        return commitAndReturn(updateContext, newRoot, size);
+    }
+
     protected void commit(UpdateContext<?> updateContext) {
         updateContext.commit();
     }

--- a/javersion-util/src/main/java/org/javersion/util/AbstractTrieSet.java
+++ b/javersion-util/src/main/java/org/javersion/util/AbstractTrieSet.java
@@ -27,7 +27,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 
 
-public abstract class AbstractTrieSet<E, S extends AbstractTrieSet<E, S>> extends AbstractHashTrie<E, EntryNode<E>, S> implements Iterable<E> {
+public abstract class AbstractTrieSet<E, This extends AbstractTrieSet<E, This>> extends AbstractHashTrie<E, EntryNode<E>, This> implements Iterable<E> {
 
     @SuppressWarnings("rawtypes")
     private static final Function ELEMENT_TO_ENTRY = new Function() {
@@ -46,7 +46,7 @@ public abstract class AbstractTrieSet<E, S extends AbstractTrieSet<E, S>> extend
         }
     };
 
-    public S conj(E element) {
+    public This conj(E element) {
         final UpdateContext<EntryNode<E>> updateContext = updateContext(1, null);
         try {
             return doAdd(updateContext, new EntryNode<E>(element));
@@ -55,32 +55,41 @@ public abstract class AbstractTrieSet<E, S extends AbstractTrieSet<E, S>> extend
         }
     }
 
-    public S conjAll(final Collection<? extends E> elements) {
+    public This conjAll(final Collection<? extends E> elements) {
         return conjAll(elements, elements.size());
     }
 
-    public S conjAll(AbstractTrieSet<? extends E, ?> elements) {
+    public This conjAll(AbstractTrieSet<? extends E, ?> elements) {
         return conjAll(elements, elements.size());
     }
 
-    public S conjAll(final Iterable<? extends E> elements) {
+    public This conjAll(final Iterable<? extends E> elements) {
         return conjAll(elements, 32);
     }
 
     @SuppressWarnings("unchecked")
-    private S conjAll(final Iterable<? extends E> elements, int size) {
+    private This conjAll(final Iterable<? extends E> elements, int size) {
         final UpdateContext<EntryNode<E>> updateContext = updateContext(size, null);
         try {
-            return (S) doAddAll(updateContext, transform(elements.iterator(), ELEMENT_TO_ENTRY));
+            return (This) doAddAll(updateContext, transform(elements.iterator(), ELEMENT_TO_ENTRY));
         } finally {
             commit(updateContext);
         }
     }
 
-    public S disj(Object element) {
+    public This disj(Object element) {
         final UpdateContext<EntryNode<E>> updateContext = updateContext(1, null);
         try {
             return doRemove(updateContext, element);
+        } finally {
+            commit(updateContext);
+        }
+    }
+
+    public This disjAll(final Iterable<? extends E> elements) {
+        final UpdateContext<EntryNode<E>> updateContext = updateContext(1, null);
+        try {
+            return doRemoveAll(updateContext, elements.iterator());
         } finally {
             commit(updateContext);
         }

--- a/javersion-util/src/main/java/org/javersion/util/PersistentHashSet.java
+++ b/javersion-util/src/main/java/org/javersion/util/PersistentHashSet.java
@@ -73,5 +73,4 @@ public class PersistentHashSet<E> extends AbstractTrieSet<E, PersistentHashSet<E
     public String toString() {
         return stream().map(Objects::toString).collect(Collectors.joining(", ", "[", "]"));
     }
-
 }

--- a/javersion-util/src/test/java/org/javersion/util/PersistentHashSetTest.java
+++ b/javersion-util/src/test/java/org/javersion/util/PersistentHashSetTest.java
@@ -17,11 +17,7 @@ package org.javersion.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.Spliterator;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -31,7 +27,7 @@ import org.assertj.core.api.Assertions;
 import org.javersion.util.PersistentHashMapTest.HashKey;
 import org.junit.Test;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 
 public class PersistentHashSetTest {
 
@@ -75,11 +71,14 @@ public class PersistentHashSetTest {
     }
 
     @Test
-    public void Add_All() {
+    public void add_and_remove_all() {
         PersistentHashSet<Integer> set = new PersistentHashSet<>();
         Set<Integer> ints = integers();
         set = set.conjAll(ints);
         assertThat(set.asSet()).isEqualTo(ints);
+        set = set.disjAll(ints);
+        assertThat(set.asSet()).isEqualTo(new HashSet<>());
+        assertThat(set.size()).isEqualTo(0);
     }
 
     @Test

--- a/javersion-util/src/test/java/org/javersion/util/PersistentTreeSetTest.java
+++ b/javersion-util/src/test/java/org/javersion/util/PersistentTreeSetTest.java
@@ -31,7 +31,7 @@ import java.util.stream.StreamSupport;
 
 import org.junit.Test;
 
-public class PersitentTreeSetTest {
+public class PersistentTreeSetTest {
 
     private static final Random RANDOM = new Random(2007);
 


### PR DESCRIPTION
Define relevant versions to keep and squash unnecessary versions. Retains lowest common ancestors of kept revisions for merge.