### PR TITLE
Configurable cache compaction

### DIFF
--- a/javersion-core/src/main/java/org/javersion/core/OptimizedGraphBuilder.java
+++ b/javersion-core/src/main/java/org/javersion/core/OptimizedGraphBuilder.java
@@ -50,7 +50,7 @@ public class OptimizedGraphBuilder<K, V, M> {
         // optimizedVersions and heads are in reverse topological order (newest first)
         for (VersionNode<K, V, M> versionNode : versionGraph.getVersionNodes()) {
             List<OptimizedVersionBuilder<K, V, M>> children = findChildren(heads, versionNode.revision);
-            Set<Revision> directChildRevisions = directChildrenRevisions(children);
+            Set<Revision> directChildRevisions = directChildRevisions(children);
             if (directChildRevisions.size() > 1 || keep.test(versionNode)) {
                 keep(versionNode, children, directChildRevisions);
             } else {
@@ -119,7 +119,7 @@ public class OptimizedGraphBuilder<K, V, M> {
                 .collect(Collectors.toList());
     }
 
-    private Set<Revision> directChildrenRevisions(List<OptimizedVersionBuilder<K, V, M>> children) {
+    private Set<Revision> directChildRevisions(List<OptimizedVersionBuilder<K, V, M>> children) {
         Set<Revision> result = Sets.newHashSetWithExpectedSize(children.size());
         for (int i = children.size()-1; i >= 0; i--) {
             boolean redundant = false;

--- a/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
+++ b/javersion-core/src/main/java/org/javersion/core/VersionGraph.java
@@ -178,9 +178,9 @@ public abstract class VersionGraph<K, V, M,
         return optimize(versionNode -> revisions.contains(versionNode.revision));
     }
 
-    public This optimize(Predicate<VersionNode<K, V, M>> revisions) {
+    public This optimize(Predicate<VersionNode<K, V, M>> keep) {
         B builder = newEmptyBuilder();
-        for (Version<K, V, M> version : new OptimizedGraphBuilder<>(this, revisions).getOptimizedVersions()) {
+        for (Version<K, V, M> version : new OptimizedGraphBuilder<>(this, keep).getOptimizedVersions()) {
             builder.add(version);
         }
         return builder.build();

--- a/javersion-spring-jdbc/src/main/java/org/javersion/store/jdbc/CacheOptions.java
+++ b/javersion-spring-jdbc/src/main/java/org/javersion/store/jdbc/CacheOptions.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 Samppa Saarela
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.javersion.store.jdbc;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.javersion.core.Revision;
+import org.javersion.core.VersionGraph;
+import org.javersion.core.VersionNode;
+import org.javersion.path.PropertyPath;
+import org.javersion.util.Check;
+
+import com.google.common.base.Function;
+
+@Immutable
+public class CacheOptions<Id, M> {
+
+    public static class KeepHeadsAndNewest<M> implements Predicate<VersionNode<PropertyPath, Object, M>> {
+
+        private int keepCount;
+
+        private final Set<Revision> heads;
+
+        public KeepHeadsAndNewest(VersionGraph<PropertyPath, Object, M, ?, ?> graph, int count) {
+            Check.that(count >= 0, "count should be >= 0");
+            keepCount = count;
+            heads = graph.getHeads().keyStream()
+                    .map(branchAndRevision -> branchAndRevision.revision)
+                    .collect(toSet());
+        }
+
+        @Override
+        public boolean test(VersionNode<PropertyPath, Object, M> versionNode) {
+            return heads.contains(versionNode.revision) || keepCount-- > 0;
+        }
+    }
+
+    public static <Id, M> CacheOptions<Id, M> keepHeadsAndNewest(final int count, final int compactThreshold) {
+        Check.that(count >= 0, "count should be >= 0");
+        Check.that(compactThreshold > count, "compactThreshold should be > count");
+        return new CacheOptions<>(
+                g -> g.versionNodes.size() - g.getHeads().size() >=  compactThreshold,
+                (g) -> new KeepHeadsAndNewest<>(g, count)
+        );
+    }
+
+    @Nonnull
+    public final Predicate<VersionGraph<PropertyPath, Object, M, ?, ?>> compactWhen;
+
+    @Nonnull
+    public final Function<VersionGraph<PropertyPath, Object, M, ?, ?>, Predicate<VersionNode<PropertyPath, Object, M>>> compactKeep;
+
+    public CacheOptions() {
+        this(null, null);
+    }
+
+    public CacheOptions(@Nullable Predicate<VersionGraph<PropertyPath, Object, M, ?, ?>> compactWhen,
+                        @Nullable Function<VersionGraph<PropertyPath, Object, M, ?, ?>, Predicate<VersionNode<PropertyPath, Object, M>>> compactKeep) {
+        if (compactWhen != null) {
+            if (compactKeep == null) {
+                throw new IllegalArgumentException("compactWhen requires compactKeep");
+            }
+            this.compactWhen = compactWhen;
+            this.compactKeep = compactKeep;
+        } else {
+            if (compactKeep != null) {
+                throw new IllegalArgumentException("compactKeep requires compactWhen");
+            }
+            this.compactWhen = g -> false;
+            this.compactKeep = (g) -> v -> true;
+        }
+    }
+
+}


### PR DESCRIPTION
Drop unnecessary older versions from cache. Configurable with

* a predicate that says when compaction should occur for given graph (e.g. size threshold)
* a factory function that produces a keep predicate for compaction (VersionGraph.optimize())